### PR TITLE
[IMP] Add queue_job.keep_context ir.config_parameter

### DIFF
--- a/queue_job/fields.py
+++ b/queue_job/fields.py
@@ -70,6 +70,8 @@ class JobEncoder(json.JSONEncoder):
     """Encode Odoo recordsets so that we can later recompose them"""
 
     def _get_record_context(self, obj):
+        if obj.env["ir.config_parameter"].sudo().get_param("queue_job.keep_context"):
+            return obj.env.context
         return obj._job_prepare_context_before_enqueue()
 
     def default(self, obj):

--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -32,6 +32,23 @@ class TestJson(common.TransactionCase):
         }
         self.assertEqual(json.loads(value_json), expected)
 
+    def test_encoder_recordset_keep_context(self):
+        demo_user = self.env.ref("base.user_demo")
+        self.env["ir.config_parameter"].sudo().set_param("queue_job.keep_context", True)
+        context = dict(**{"foo": "bar"}, **demo_user.context_get())
+        partner = self.env(user=demo_user, context=context).ref("base.main_partner")
+        value = partner
+        value_json = json.dumps(value, cls=JobEncoder)
+        expected = {
+            "uid": demo_user.id,
+            "_type": "odoo_recordset",
+            "model": "res.partner",
+            "ids": [partner.id],
+            "su": False,
+            "context": {"foo": "bar", "tz": context["tz"], "lang": context["lang"]},
+        }
+        self.assertEqual(json.loads(value_json), expected)
+
     def test_encoder_recordset_list(self):
         demo_user = self.env.ref("base.user_demo")
         context = demo_user.context_get()


### PR DESCRIPTION
When this parameter is set, queue_job always preserves the entire context. This honors the principle of least surprise, in that a developer can easily convert a record.method() call to record.with_delay().method() with the expectation that it will actually execute the same, simply at a later time.